### PR TITLE
Add horizontal margin around paginator select.

### DIFF
--- a/src/components/paginator.jsx
+++ b/src/components/paginator.jsx
@@ -22,6 +22,7 @@ const Paginator = ({
   pageSelector,
   previousLabel,
   router,
+  selectionText,
   totalItems,
 }) => {
   let pageChange;
@@ -90,7 +91,7 @@ const Paginator = ({
             onChange={(e) => { pageChange(e.target.value); }}
           >
             {[...Array(pageCount).keys()].map(i => pageOption(i + 1))}
-          </select> OF {pageCount}
+          </select>{selectionText} {pageCount}
         </div>)}
 
       {itemCount && totalItems &&
@@ -134,6 +135,7 @@ Paginator.defaultProps = {
   pageKey: 'page',
   pageSelector: true,
   previousLabel: <span className="paginator-label"><span className="paginator-icon">&lsaquo;</span> previous</span>,
+  selectionText: 'OF'
 };
 
 Paginator.propTypes = {
@@ -166,6 +168,7 @@ Paginator.propTypes = {
   router: React.PropTypes.shape({
     push: React.PropTypes.func,
   }),
+  selectionText: React.PropTypes.string,
   totalItems: React.PropTypes.oneOfType([
     React.PropTypes.node,
     React.PropTypes.string,

--- a/src/css/paginator.styl
+++ b/src/css/paginator.styl
@@ -27,3 +27,6 @@
     margin-left: .25em
     margin-right: .25em
     white-space: nowrap
+
+  .paginator-page-selector select
+    margin 0 .5em


### PR DESCRIPTION
- Removed space before 'of'
- Added horizontal margin to `select` selector
- Replaced hardcoded 'OF' string with prop for translation support

Before: 
![image](https://user-images.githubusercontent.com/12473119/28602560-62b0c502-7184-11e7-969e-13a912625da0.png)

After:
![image](https://user-images.githubusercontent.com/12473119/28602564-69444042-7184-11e7-8272-fc53b718a5d7.png)

