### PR TITLE
edit display-name-slug-editor origin and url in form-help

### DIFF
--- a/src/components/display-name-slug-editor.jsx
+++ b/src/components/display-name-slug-editor.jsx
@@ -95,7 +95,7 @@ class DisplayNameSlugEditor extends Component {
               Your {resourceType}’s URL is
               {' '}
               <a href={this.props.origin + state.url}>
-                {state.url}
+                {this.props.origin + state.url}
               </a>
             </small>
           : null

--- a/test/display-name-slug-editor.test.js
+++ b/test/display-name-slug-editor.test.js
@@ -63,8 +63,10 @@ describe('<DisplayNameSlugEditor />', function() {
   describe('component lifecycle', function() {
     const getResourceUrlSpy = sinon.spy(DisplayNameSlugEditor.prototype, 'getResourceUrl');
 
+    const origin = 'https://www.test.com';
+
     before(function() {
-      wrapper = mount(<DisplayNameSlugEditor resource={resource} resourceType="project" />);
+      wrapper = mount(<DisplayNameSlugEditor origin={origin} resource={resource} resourceType="project" />);
     });
 
     describe('componentDidMount', function() {
@@ -85,7 +87,7 @@ describe('<DisplayNameSlugEditor />', function() {
       it('should set url to a concatenated string with the display_name and resourceType', function() {
         const url = `/projects/${resource.slug}`;
         expect(wrapper.state().url).to.equal(url);
-        expect(wrapper.find('a').text()).to.equal(url);
+        expect(wrapper.find('a').text()).to.equal(`${origin + url}`);
       });
     });
 
@@ -102,7 +104,7 @@ describe('<DisplayNameSlugEditor />', function() {
       it('updates the value and url state', function() {
         const url = `/projects/${orgResource.slug}`;
         expect(wrapper.state().url).to.equal(url);
-        expect(wrapper.find('a').text()).to.equal(url);
+        expect(wrapper.find('a').text()).to.equal(`${origin + url}`);
         expect(wrapper.state().value).to.equal(orgResource.display_name);
         expect(wrapper.find('input[type="text"]').props().value).to.equal(orgResource.display_name);
       });


### PR DESCRIPTION
Closes #28. 

- Edits display-name-slug-editor form-help content to show origin and url, instead of just url
- Updates tests accordingly