### PR TITLE
Add StepThrough and MediaCard Exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.1] 2017-10-17
+### Fixed
+- Added exports for MediaCard and StepThrough components
+
 ## [0.6.0] 2017-10-16
 ### Added
 - MediaCard component and tests

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,4 +193,22 @@ Object.defineProperty(exports, 'Tutorial', {
   }
 });
 
+var _stepThrough = require('./components/step-through');
+
+Object.defineProperty(exports, 'StepThrough', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_stepThrough).default;
+  }
+});
+
+var _mediaCard = require('./components/media-card');
+
+Object.defineProperty(exports, 'MediaCard', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_mediaCard).default;
+  }
+});
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,22 +193,4 @@ Object.defineProperty(exports, 'Tutorial', {
   }
 });
 
-var _stepThrough = require('./components/step-through');
-
-Object.defineProperty(exports, 'StepThrough', {
-  enumerable: true,
-  get: function get() {
-    return _interopRequireDefault(_stepThrough).default;
-  }
-});
-
-var _mediaCard = require('./components/media-card');
-
-Object.defineProperty(exports, 'MediaCard', {
-  enumerable: true,
-  get: function get() {
-    return _interopRequireDefault(_mediaCard).default;
-  }
-});
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/src/index.js
+++ b/src/index.js
@@ -21,3 +21,5 @@ export { default as OauthGoogleIcon } from './components/layout/oauth-google-ico
 export { default as UserMenu } from './components/layout/user-menu';
 export { default as UserNavigation } from './components/layout/user-navigation';
 export { default as Tutorial } from './components/tutorial';
+export { default as MediaCard } from './components/media-card';
+export { default as StepThrough } from './components/step-through';


### PR DESCRIPTION
Forgot these in the 0.6.0 release. This PR should fix the exports and allow these two components to be available standalone.