### PR TITLE
Only show google sign in if function is defined

### DIFF
--- a/src/components/layout/layout.md
+++ b/src/components/layout/layout.md
@@ -214,7 +214,7 @@ A modal for presenting options for oauth authentication with Panoptes. This will
 |----------|-----------------|--------------|-------|
 | heading  | PropTypes.string  | 'Sign In'        |       |
 | login    | PropTypes.func | () => {} | Define a function to oauth sign in with Panoptes which should redirect to Panoptes devise view. Using the panoptes-javascript-client, this funciton will probably be `oauth.signIn(computeRedirectURL(window))`. An example is in zoo-reduxify |
-| loginWithGoogle | PropTypes.func  | () => {}     | Define a function to redirect Panoptes sign in with Google page directly |
+| loginWithGoogle | PropTypes.func  | null | Define a function to redirect Panoptes sign in with Google page directly. If none is defined, then the button is hidden on the OauthModal |
 | onClose  | PropTypes.func  | () => {}        | Define a function to close the modal (Set state to false) |
 | showOauthModal    | PropTypes.bool | false | Boolean visibility state of the modal |
 | signInGoogleLabel | PropTypes.string  | 'Sign in with Google'     |       |

--- a/src/components/layout/oauth-modal.jsx
+++ b/src/components/layout/oauth-modal.jsx
@@ -13,10 +13,11 @@ export default function OauthModal(props) {
         <Box pad="medium" justify="between">
           <Heading tag="h2">{props.heading}</Heading>
           <Button className="oauth-modal__button--panoptes" label={props.signInLabel} onClick={props.login} primary={true} />
-          <Button className="oauth-modal__button--google" onClick={props.loginWithGoogle} plain={true}>
-            <OauthGoogleIcon className="oauth-modal__google-icon" />
-            <span className="oauth-modal__google-label">{props.signInGoogleLabel}</span>
-          </Button>
+          {props.loginWithGoogle &&
+            <Button className="oauth-modal__button--google" onClick={props.loginWithGoogle} plain={true}>
+              <OauthGoogleIcon className="oauth-modal__google-icon" />
+              <span className="oauth-modal__google-label">{props.signInGoogleLabel}</span>
+            </Button>}
         </Box>
       </Layer>
     );
@@ -28,7 +29,7 @@ export default function OauthModal(props) {
 OauthModal.defaultProps = {
   heading: 'Sign In',
   login: () => {},
-  loginWithGoogle: () => {},
+  loginWithGoogle: null,
   onClose: () => {},
   showOauthModal: false,
   signInGoogleLabel: 'Sign in with Google',

--- a/src/components/layout/signed-out-user-navigation.jsx
+++ b/src/components/layout/signed-out-user-navigation.jsx
@@ -25,7 +25,7 @@ export default function SignedOutUserNavigation(props) {
 
 SignedOutUserNavigation.defaultProps = {
   login: () => {},
-  loginWithGoogle: () => {},
+  loginWithGoogle: null,
   showOauthModal: false,
   toggleModal: () => {},
   useOauth: false

--- a/test/oauth-modal.test.js
+++ b/test/oauth-modal.test.js
@@ -42,4 +42,9 @@ describe('<OauthModal />', function() {
     loginWithGoogleButton.simulate('click');
     expect(loginWithGoogleSpy.calledOnce).to.be.true;
   });
+
+  it('hides the Google sign in button if props.loginWithGoogle is not defined', function() {
+    wrapper.setProps({ loginWithGoogle: null });
+    expect(wrapper.find('Button')).to.have.lengthOf(1);
+  })
 });


### PR DESCRIPTION
Patch to only show the google sign in button on the oauth modal if the sign in function is defined. 