### PR TITLE
Update to v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.3] 2021-10-21
+### Security
+- Dependency security patches
+
 ## [0.9.2] 2021-06-08
 ### Security
 - Dependency security patches

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zooniverse-react-components",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Zooniverse-React-Components ===========================",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Towards #90. 

- updates CHANGELOG
- edits package.json, adds git tag to v0.9.3

I think the following list comprises active code/repos using ZRC that'll need updating:

https://github.com/zooniverse/pfe-lab
https://github.com/zooniverse/scribes-of-the-cairo-geniza
https://github.com/zooniverse/anti-slavery-manuscripts
https://github.com/zooniverse/edu-api-front-end 
https://github.com/zooniverse/notes-from-nature-field-book

*npm link issue notes*
For Scribes and ASM I had to add `symlinks: false` to the dev webpack config, as per https://webpack.js.org/configuration/resolve/#resolvesymlinks.
For EduAPIFrontEnd I had to update package.json to this branch (`"zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#version-0.9.3"`), which could also be used for any of the repos noted instead of `npm link`.