### PR TITLE
[Security] Update markdownz and panoptes-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "grommet": "^1.8.2",
         "markdownz": "^7.8.1",
         "modal-form": "^2.9.1",
-        "panoptes-client": "^3.3.2",
+        "panoptes-client": "^3.3.4",
         "prop-types": "^15.7.2",
         "react-select": "1.0.0-rc.10",
         "react-swipe": "^6.0.4"
@@ -5920,13 +5920,13 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.2.tgz",
-      "integrity": "sha512-fb6Tah+M8QTZ/cSU6BE8/1+hatS1AVmj29iZj7hAdprvhenfcJcyj/C4eLEbbEmzXS7ZeOVJ3ESUY5KngAfivg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.4.tgz",
+      "integrity": "sha512-37ZxdLBUkTBmo/eoCyVYijvsnvnCXt9lzKfwbVKFmYlMCSujlDBmHIb4lKSiaKd3Jg3r19NqGiqTQF1ZO4U5pg==",
       "dependencies": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.0.1"
+        "sugar-client": "^1.1.0"
       }
     },
     "node_modules/parent-module": {
@@ -7154,9 +7154,12 @@
       }
     },
     "node_modules/sugar-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.0.1.tgz",
-      "integrity": "sha1-zRhz+/Kn2smm8prKHq2hr3UTz58="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.1.0.tgz",
+      "integrity": "sha512-/1fgJcTUQPUw4hrT/AXpI4iVdsoXIIgVrbj3mPGMJWD00JHtWna5KmKyeoqNKSCO672UK+5Cc9/B53UfzthbwA==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/superagent": {
       "version": "3.8.3",
@@ -12959,13 +12962,13 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.2.tgz",
-      "integrity": "sha512-fb6Tah+M8QTZ/cSU6BE8/1+hatS1AVmj29iZj7hAdprvhenfcJcyj/C4eLEbbEmzXS7ZeOVJ3ESUY5KngAfivg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.4.tgz",
+      "integrity": "sha512-37ZxdLBUkTBmo/eoCyVYijvsnvnCXt9lzKfwbVKFmYlMCSujlDBmHIb4lKSiaKd3Jg3r19NqGiqTQF1ZO4U5pg==",
       "requires": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.0.1"
+        "sugar-client": "^1.1.0"
       }
     },
     "parent-module": {
@@ -14020,9 +14023,9 @@
       }
     },
     "sugar-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.0.1.tgz",
-      "integrity": "sha1-zRhz+/Kn2smm8prKHq2hr3UTz58="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.1.0.tgz",
+      "integrity": "sha512-/1fgJcTUQPUw4hrT/AXpI4iVdsoXIIgVrbj3mPGMJWD00JHtWna5KmKyeoqNKSCO672UK+5Cc9/B53UfzthbwA=="
     },
     "superagent": {
       "version": "3.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "zooniverse-react-components",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zooniverse-react-components",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "animated-scrollto": "^1.1.0",
         "data-uri-to-blob": "0.0.4",
         "grommet": "^1.8.2",
-        "markdownz": "^7.7.1",
+        "markdownz": "^7.8.1",
         "modal-form": "^2.9.1",
         "panoptes-client": "^3.3.2",
         "prop-types": "^15.7.2",
@@ -1568,6 +1568,28 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -4069,6 +4091,27 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -4214,8 +4257,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "node_modules/grommet": {
       "version": "1.13.0",
@@ -4901,6 +4943,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "dependencies": {
+        "universalify": "^0.1.2"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5182,24 +5235,28 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
-      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg=="
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
     },
     "node_modules/markdown-it-container": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-2.0.0.tgz",
-      "integrity": "sha1-ABm0P9Au7+zi8ZYKKJX7qBpARpU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw=="
     },
     "node_modules/markdown-it-emoji": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.2.0.tgz",
-      "integrity": "sha1-VUqXdn1mI5NuHI1DBn8OQbeWqsM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz",
+      "integrity": "sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ=="
     },
     "node_modules/markdown-it-footnote": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.2.tgz",
-      "integrity": "sha512-JVW6fCmZWjvMdDQSbOT3nnOQtd9iAXmw7hTSh26+v42BnvXeVyGMDBm5b/EZocMed2MbCAHiTX632vY0FyGB8A=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
     },
     "node_modules/markdown-it-html5-embed": {
       "version": "1.0.0",
@@ -5226,17 +5283,17 @@
       "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
     },
     "node_modules/markdown-it-table-of-contents": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
-      "integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz",
+      "integrity": "sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ==",
       "engines": {
         "node": ">6.4.0"
       }
     },
     "node_modules/markdown-it-video": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.4.0.tgz",
-      "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.6.3.tgz",
+      "integrity": "sha512-T4th1kwy0OcvyWSN4u3rqPGxvbDclpucnVSSaH3ZacbGsAts964dxokx9s/I3GYsrDCJs4ogtEeEeVP18DQj0Q=="
     },
     "node_modules/markdown-to-jsx": {
       "version": "6.11.4",
@@ -5261,22 +5318,62 @@
       }
     },
     "node_modules/markdownz": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.7.1.tgz",
-      "integrity": "sha512-hrnNr1CGKKPE9Pqpv/2hrwjd6EGfvigUSr0SiLnRZj1oyJoio7CHT7CwA2iWmrcq2kYBG616kZEguYcO0x7C9Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.8.1.tgz",
+      "integrity": "sha512-StQcR9WM00Dl4XDCLKtKnsRe32mgvbNevbQbmAJbyaJv+kead0NJkHY82/cWFaVkOoQRf9lJ+umhKEA6a1M+Hg==",
       "dependencies": {
-        "markdown-it": "~8.4.1",
-        "markdown-it-anchor": "~5.0.2",
-        "markdown-it-container": "~2.0.0",
-        "markdown-it-emoji": "~1.2.0",
-        "markdown-it-footnote": "~3.0.1",
+        "markdown-it": "~12.3.2",
+        "markdown-it-anchor": "~8.4.1",
+        "markdown-it-container": "~3.0.0",
+        "markdown-it-emoji": "~2.0.0",
+        "markdown-it-footnote": "~3.0.3",
         "markdown-it-html5-embed": "~1.0.0",
         "markdown-it-imsize": "~2.0.1",
         "markdown-it-sub": "~1.0.0",
         "markdown-it-sup": "~1.0.0",
-        "markdown-it-table-of-contents": "~0.4.0",
-        "markdown-it-video": "~0.4.0",
-        "twemoji": "~1.4.1"
+        "markdown-it-table-of-contents": "~0.6.0",
+        "markdown-it-video": "~0.6.3",
+        "twemoji": "~13.1.0"
+      },
+      "peerDependencies": {
+        "react": ">= 15.6",
+        "react-dom": ">= 15.6"
+      }
+    },
+    "node_modules/markdownz/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/markdownz/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/markdownz/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdownz/node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/mdurl": {
@@ -6087,7 +6184,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
       "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -6106,7 +6202,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
       "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -6118,7 +6213,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6260,7 +6354,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6626,7 +6719,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -7262,9 +7354,20 @@
       "dev": true
     },
     "node_modules/twemoji": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.4.1.tgz",
-      "integrity": "sha1-CEfVf+/t/3Kxv9v+4G+CJRBmNHE="
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-13.1.0.tgz",
+      "integrity": "sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==",
+      "dependencies": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "13.1.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "node_modules/twemoji-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.1.0.tgz",
+      "integrity": "sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -7363,6 +7466,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unquote": {
@@ -9180,6 +9291,28 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "peer": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "peer": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "peer": true
     },
     "abab": {
       "version": "2.0.5",
@@ -11293,6 +11426,26 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -11411,8 +11564,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "grommet": {
       "version": "1.13.0",
@@ -11993,6 +12145,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^0.1.2"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -12233,24 +12394,25 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
-      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg=="
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "requires": {}
     },
     "markdown-it-container": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-2.0.0.tgz",
-      "integrity": "sha1-ABm0P9Au7+zi8ZYKKJX7qBpARpU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw=="
     },
     "markdown-it-emoji": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.2.0.tgz",
-      "integrity": "sha1-VUqXdn1mI5NuHI1DBn8OQbeWqsM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz",
+      "integrity": "sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ=="
     },
     "markdown-it-footnote": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.2.tgz",
-      "integrity": "sha512-JVW6fCmZWjvMdDQSbOT3nnOQtd9iAXmw7hTSh26+v42BnvXeVyGMDBm5b/EZocMed2MbCAHiTX632vY0FyGB8A=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
     },
     "markdown-it-html5-embed": {
       "version": "1.0.0",
@@ -12277,14 +12439,14 @@
       "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
     },
     "markdown-it-table-of-contents": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
-      "integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz",
+      "integrity": "sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ=="
     },
     "markdown-it-video": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.4.0.tgz",
-      "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.6.3.tgz",
+      "integrity": "sha512-T4th1kwy0OcvyWSN4u3rqPGxvbDclpucnVSSaH3ZacbGsAts964dxokx9s/I3GYsrDCJs4ogtEeEeVP18DQj0Q=="
     },
     "markdown-to-jsx": {
       "version": "6.11.4",
@@ -12308,22 +12470,54 @@
       }
     },
     "markdownz": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.7.1.tgz",
-      "integrity": "sha512-hrnNr1CGKKPE9Pqpv/2hrwjd6EGfvigUSr0SiLnRZj1oyJoio7CHT7CwA2iWmrcq2kYBG616kZEguYcO0x7C9Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.8.1.tgz",
+      "integrity": "sha512-StQcR9WM00Dl4XDCLKtKnsRe32mgvbNevbQbmAJbyaJv+kead0NJkHY82/cWFaVkOoQRf9lJ+umhKEA6a1M+Hg==",
       "requires": {
-        "markdown-it": "~8.4.1",
-        "markdown-it-anchor": "~5.0.2",
-        "markdown-it-container": "~2.0.0",
-        "markdown-it-emoji": "~1.2.0",
-        "markdown-it-footnote": "~3.0.1",
+        "markdown-it": "~12.3.2",
+        "markdown-it-anchor": "~8.4.1",
+        "markdown-it-container": "~3.0.0",
+        "markdown-it-emoji": "~2.0.0",
+        "markdown-it-footnote": "~3.0.3",
         "markdown-it-html5-embed": "~1.0.0",
         "markdown-it-imsize": "~2.0.1",
         "markdown-it-sub": "~1.0.0",
         "markdown-it-sup": "~1.0.0",
-        "markdown-it-table-of-contents": "~0.4.0",
-        "markdown-it-video": "~0.4.0",
-        "twemoji": "~1.4.1"
+        "markdown-it-table-of-contents": "~0.6.0",
+        "markdown-it-video": "~0.6.3",
+        "twemoji": "~13.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "linkify-it": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+          "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+          "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
       }
     },
     "mdurl": {
@@ -12981,7 +13175,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
       "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -12992,7 +13185,6 @@
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
           "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -13010,7 +13202,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
       "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -13022,7 +13213,6 @@
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
           "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
@@ -13468,7 +13658,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -14003,9 +14192,20 @@
       "dev": true
     },
     "twemoji": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.4.1.tgz",
-      "integrity": "sha1-CEfVf+/t/3Kxv9v+4G+CJRBmNHE="
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-13.1.0.tgz",
+      "integrity": "sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==",
+      "requires": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "13.1.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "twemoji-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.1.0.tgz",
+      "integrity": "sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -14080,6 +14280,11 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unquote": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "animated-scrollto": "^1.1.0",
     "data-uri-to-blob": "0.0.4",
     "grommet": "^1.8.2",
-    "markdownz": "^7.7.1",
+    "markdownz": "^7.8.1",
     "modal-form": "^2.9.1",
     "panoptes-client": "^3.3.2",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "grommet": "^1.8.2",
     "markdownz": "^7.8.1",
     "modal-form": "^2.9.1",
-    "panoptes-client": "^3.3.2",
+    "panoptes-client": "^3.3.4",
     "prop-types": "^15.7.2",
     "react-select": "1.0.0-rc.10",
     "react-swipe": "^6.0.4"


### PR DESCRIPTION
Updates markdownz to v7.8.1 and panoptes-client to v3.3.4. Both updates include dependency security updates.

After merge, bump ZRC to v0.9.4 and update related apps:
- NfN Field Book
- pfe-lab
- scribes
- ASM
- edu-API-front-end
