### PR TITLE
Update to v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.6] 2022-08-30
+### Updated
+- README with dependents
+### Fixed
+- Version issue
+
 ## [0.9.5] 2022-08-19
 ### Security
 - Dependency security patches

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zooniverse-react-components",
-  "version": "0.9.4",
+  "version": "0.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zooniverse-react-components",
-      "version": "0.9.4",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "animated-scrollto": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zooniverse-react-components",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Zooniverse-React-Components ===========================",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes issue with mismatched `package.json` and `package-lock.json` and updates CHANGELOG accordingly.