### PR TITLE
Update ZRC to v0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.9.7]
 ### Updated
 - panoptes-client for security and dependency updates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zooniverse-react-components",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zooniverse-react-components",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "Apache-2.0",
       "dependencies": {
         "animated-scrollto": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zooniverse-react-components",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Zooniverse-React-Components ===========================",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Updates Zooniverse-React-Components to v0.9.7.

I'll update dependent repos asap:

  - [ ] [anti-slavery-manuscripts](https://github.com/zooniverse/anti-slavery-manuscripts)
  - [ ] [classroom](https://github.com/zooniverse/classroom)
  - [ ] [notes-from-nature-field-book](https://github.com/zooniverse/notes-from-nature-field-book)
  - [ ] [pfe-lab](https://github.com/zooniverse/pfe-lab)
  - [ ] [scribes-of-the-cairo-geniza](https://github.com/zooniverse/scribes-of-the-cairo-geniza)