### PR TITLE
Build and test with Node 18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,10 @@ jobs:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
     - uses: actions/checkout@v3
 
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 'lts/hydrogen'
         cache: 'npm'
     - run: npm ci
     - run: npm test


### PR DESCRIPTION
Node 16 entered maintenance mode in October 2022 and support ends in September 2023.